### PR TITLE
Make background white for transparent images

### DIFF
--- a/app/src/main/res/layout-land/activity_draw.xml
+++ b/app/src/main/res/layout-land/activity_draw.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="horizontal"
-              tools:context="com.rm.freedrawsample.ActivityDraw">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:background="@color/white"
+    tools:context="com.rm.freedrawsample.ActivityDraw">
 
     <ImageView
         android:id="@+id/img_screen"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="fitCenter"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 
     <com.rm.freedrawview.FreeDrawView
         android:id="@+id/free_draw_view"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:background="@color/white"/>
+        android:background="@color/white" />
 
     <RelativeLayout
         android:id="@+id/side_view"
@@ -48,12 +49,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Stroke width"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <SeekBar
                         android:id="@+id/slider_thickness"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"/>
+                        android:layout_height="wrap_content" />
                 </LinearLayout>
 
                 <LinearLayout
@@ -67,12 +68,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Stroke alpha"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <SeekBar
                         android:id="@+id/slider_alpha"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"/>
+                        android:layout_height="wrap_content" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -93,7 +94,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:text="Undo"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <TextView
                         android:id="@+id/txt_undo_count"
@@ -103,7 +104,7 @@
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
                         android:padding="12dp"
-                        android:textColor="@color/white"/>
+                        android:textColor="@color/white" />
                 </RelativeLayout>
 
                 <RelativeLayout
@@ -117,7 +118,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:text="redo"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <TextView
                         android:id="@+id/txt_redo_count"
@@ -127,7 +128,7 @@
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
                         android:padding="12dp"
-                        android:textColor="@color/white"/>
+                        android:textColor="@color/white" />
                 </RelativeLayout>
             </LinearLayout>
 
@@ -144,7 +145,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:text="Random color"
-                    android:textColor="@android:color/white"/>
+                    android:textColor="@android:color/white" />
 
                 <Button
                     android:id="@+id/btn_clear_all"
@@ -153,7 +154,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:text="clear all"
-                    android:textColor="@android:color/white"/>
+                    android:textColor="@android:color/white" />
             </LinearLayout>
         </LinearLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/activity_draw.xml
+++ b/app/src/main/res/layout/activity_draw.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              tools:context="com.rm.freedrawsample.ActivityDraw">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/white"
+    tools:context="com.rm.freedrawsample.ActivityDraw">
 
     <ImageView
         android:id="@+id/img_screen"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="fitCenter"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 
     <com.rm.freedrawview.FreeDrawView
         android:id="@+id/free_draw_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:background="@color/white"/>
+        android:background="@color/white" />
 
     <RelativeLayout
         android:id="@+id/side_view"
@@ -48,12 +49,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Stroke width"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <SeekBar
                         android:id="@+id/slider_thickness"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"/>
+                        android:layout_height="wrap_content" />
                 </LinearLayout>
 
                 <LinearLayout
@@ -67,12 +68,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Stroke alpha"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <SeekBar
                         android:id="@+id/slider_alpha"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"/>
+                        android:layout_height="wrap_content" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -93,7 +94,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:text="Undo"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <TextView
                         android:id="@+id/txt_undo_count"
@@ -103,7 +104,7 @@
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
                         android:padding="12dp"
-                        android:textColor="@color/white"/>
+                        android:textColor="@color/white" />
                 </RelativeLayout>
 
                 <RelativeLayout
@@ -117,7 +118,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:text="redo"
-                        android:textColor="@android:color/white"/>
+                        android:textColor="@android:color/white" />
 
                     <TextView
                         android:id="@+id/txt_redo_count"
@@ -127,7 +128,7 @@
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
                         android:padding="12dp"
-                        android:textColor="@color/white"/>
+                        android:textColor="@color/white" />
                 </RelativeLayout>
             </LinearLayout>
 
@@ -144,7 +145,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:text="clear all"
-                    android:textColor="@android:color/white"/>
+                    android:textColor="@android:color/white" />
 
                 <Button
                     android:id="@+id/btn_color"
@@ -153,7 +154,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:text="Random color"
-                    android:textColor="@android:color/white"/>
+                    android:textColor="@android:color/white" />
             </LinearLayout>
         </LinearLayout>
     </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 10 16:51:54 CEST 2016
+#Mon Apr 03 17:14:35 CDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
When using the FreeDrawView to draw over an image (by setting src) if the image has any transparent pixels then the transparent pixels display as dark grey.  By changing the layout to have a white background, the transparent pixels display as white.