### PR TITLE
implement eraser using PorterDuff Xfer mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.rm.freedrawsample"
-        minSdkVersion 9
+        minSdkVersion 11
         targetSdkVersion 25
         versionCode 1
         versionName "1.0.0"

--- a/app/src/main/java/com/rm/freedrawsample/ActivityDraw.java
+++ b/app/src/main/java/com/rm/freedrawsample/ActivityDraw.java
@@ -30,7 +30,7 @@ public class ActivityDraw extends AppCompatActivity
 
     private FreeDrawView mFreeDrawView;
     private View mSideView;
-    private Button mBtnRandomColor, mBtnUndo, mBtnRedo, mBtnClearAll;
+    private Button mBtnRandomColor, mBtnUndo, mBtnRedo, mBtnClearAll, mBtnEraser;
     private SeekBar mThicknessBar, mAlphaBar;
     private TextView mTxtRedoCount, mTxtUndoCount;
 
@@ -56,6 +56,7 @@ public class ActivityDraw extends AppCompatActivity
         mBtnUndo = (Button) findViewById(R.id.btn_undo);
         mBtnRedo = (Button) findViewById(R.id.btn_redo);
         mBtnClearAll = (Button) findViewById(R.id.btn_clear_all);
+        mBtnEraser = (Button) findViewById(R.id.btn_eraser);
         mThicknessBar = (SeekBar) findViewById(R.id.slider_thickness);
         mAlphaBar = (SeekBar) findViewById(R.id.slider_alpha);
 
@@ -63,6 +64,7 @@ public class ActivityDraw extends AppCompatActivity
         mBtnUndo.setOnClickListener(this);
         mBtnRedo.setOnClickListener(this);
         mBtnClearAll.setOnClickListener(this);
+        mBtnEraser.setOnClickListener(this);
 
         mAlphaBar.setMax((ALPHA_MAX - ALPHA_MIN) / ALPHA_STEP);
         mAlphaBar.setProgress(mFreeDrawView.getPaintAlpha());
@@ -140,6 +142,17 @@ public class ActivityDraw extends AppCompatActivity
 
         if (id == mBtnClearAll.getId()) {
             mFreeDrawView.undoAll();
+        }
+
+        if (id == mBtnEraser.getId()) {
+            // toggle pen/eraser
+            if (mFreeDrawView.isEraser()) {
+                mFreeDrawView.setEraser(false);
+                mBtnEraser.setText("Eraser");
+            } else {
+                mFreeDrawView.setEraser(true);
+                mBtnEraser.setText("Pen");
+            }
         }
     }
 

--- a/app/src/main/res/layout-land/activity_draw.xml
+++ b/app/src/main/res/layout-land/activity_draw.xml
@@ -138,6 +138,16 @@
                 android:layout_weight="1"
                 android:orientation="horizontal">
 
+
+                <Button
+                    android:id="@+id/btn_eraser"
+                    style="@style/Base.Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:text="Erase"
+                    android:textColor="@android:color/white" />
+
                 <Button
                     android:id="@+id/btn_color"
                     style="@style/Base.Widget.AppCompat.Button.Borderless"

--- a/app/src/main/res/layout/activity_draw.xml
+++ b/app/src/main/res/layout/activity_draw.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/white"
-    tools:context="com.rm.freedrawsample.ActivityDraw">
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:background="@color/white"
+              android:orientation="vertical"
+              tools:context="com.rm.freedrawsample.ActivityDraw">
 
     <ImageView
         android:id="@+id/img_screen"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="fitCenter"
-        android:visibility="gone" />
+        android:visibility="gone"/>
 
     <com.rm.freedrawview.FreeDrawView
         android:id="@+id/free_draw_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:background="@color/white" />
+        android:background="@color/white"/>
 
     <RelativeLayout
         android:id="@+id/side_view"
@@ -49,12 +49,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Stroke width"
-                        android:textColor="@android:color/white" />
+                        android:textColor="@android:color/white"/>
 
                     <SeekBar
                         android:id="@+id/slider_thickness"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"/>
                 </LinearLayout>
 
                 <LinearLayout
@@ -68,12 +68,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Stroke alpha"
-                        android:textColor="@android:color/white" />
+                        android:textColor="@android:color/white"/>
 
                     <SeekBar
                         android:id="@+id/slider_alpha"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"/>
                 </LinearLayout>
             </LinearLayout>
 
@@ -94,7 +94,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:text="Undo"
-                        android:textColor="@android:color/white" />
+                        android:textColor="@android:color/white"/>
 
                     <TextView
                         android:id="@+id/txt_undo_count"
@@ -104,7 +104,7 @@
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
                         android:padding="12dp"
-                        android:textColor="@color/white" />
+                        android:textColor="@color/white"/>
                 </RelativeLayout>
 
                 <RelativeLayout
@@ -118,7 +118,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:text="redo"
-                        android:textColor="@android:color/white" />
+                        android:textColor="@android:color/white"/>
 
                     <TextView
                         android:id="@+id/txt_redo_count"
@@ -128,7 +128,7 @@
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
                         android:padding="12dp"
-                        android:textColor="@color/white" />
+                        android:textColor="@color/white"/>
                 </RelativeLayout>
             </LinearLayout>
 
@@ -139,13 +139,22 @@
                 android:orientation="horizontal">
 
                 <Button
+                    android:id="@+id/btn_eraser"
+                    style="@style/Base.Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:text="Eraser"
+                    android:textColor="@android:color/white"/>
+
+                <Button
                     android:id="@+id/btn_clear_all"
                     style="@style/Base.Widget.AppCompat.Button.Borderless"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:text="clear all"
-                    android:textColor="@android:color/white" />
+                    android:textColor="@android:color/white"/>
 
                 <Button
                     android:id="@+id/btn_color"
@@ -154,7 +163,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:text="Random color"
-                    android:textColor="@android:color/white" />
+                    android:textColor="@android:color/white"/>
             </LinearLayout>
         </LinearLayout>
     </RelativeLayout>

--- a/freedrawview/build.gradle
+++ b/freedrawview/build.gradle
@@ -29,7 +29,7 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 11
         targetSdkVersion 25
         versionCode 1
         versionName "1.0.2"

--- a/freedrawview/src/main/java/com/rm/freedrawview/FreeDrawView.java
+++ b/freedrawview/src/main/java/com/rm/freedrawview/FreeDrawView.java
@@ -8,6 +8,8 @@ import android.graphics.Color;
 import android.graphics.ComposePathEffect;
 import android.graphics.CornerPathEffect;
 import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import android.os.AsyncTask;
 import android.os.Parcelable;
 import android.support.annotation.ColorInt;
@@ -50,6 +52,8 @@ public class FreeDrawView extends View implements View.OnTouchListener {
 
     private boolean mFinishPath = false;
 
+    private boolean mEraser = false;
+
     // Needed to draw points
     private Paint mFillPaint;
 
@@ -69,6 +73,11 @@ public class FreeDrawView extends View implements View.OnTouchListener {
 
         setOnTouchListener(this);
 
+        // Required for implementing ERASE feature
+        // See http://stackoverflow.com/a/33483016/990066
+        // setLayerType only available in SDK 11 and above
+        setLayerType(LAYER_TYPE_HARDWARE, mCurrentPaint);
+
         TypedArray a = null;
         try {
 
@@ -83,6 +92,7 @@ public class FreeDrawView extends View implements View.OnTouchListener {
                 a.recycle();
             }
         }
+
     }
 
     @Override
@@ -425,6 +435,7 @@ public class FreeDrawView extends View implements View.OnTouchListener {
 
     @Override
     protected void onDraw(Canvas canvas) {
+
         if (mPaths.size() == 0 && mPoints.size() == 0) {
             return;
         }
@@ -483,6 +494,7 @@ public class FreeDrawView extends View implements View.OnTouchListener {
         if (finishedPath && mPoints.size() > 0) {
             createHistoryPathFromPoints();
         }
+
     }
 
     // Create a path from the current points
@@ -676,4 +688,18 @@ public class FreeDrawView extends View implements View.OnTouchListener {
             }
         }
     }
+
+    public boolean isEraser() {
+        return mEraser;
+    }
+
+    public void setEraser(boolean mEraser) {
+        this.mEraser = mEraser;
+        if (mEraser) {
+            mCurrentPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
+        } else {
+            mCurrentPaint.setXfermode(null);
+        }
+    }
+
 }


### PR DESCRIPTION
This requires a bump for minimum SDK from 9 to 11 because of the View setLayer method.  This commit also has a bunch of changes to the layouts that occurred just because of reformatting.

Erases get added to undo/redo stack properly.

Also tested with screen rotation.
